### PR TITLE
test: add route test for /adults /kids

### DIFF
--- a/server/api/socks.spec.js
+++ b/server/api/socks.spec.js
@@ -1,0 +1,61 @@
+/* global describe beforeEach it */
+
+const {expect} = require('chai')
+const request = require('supertest')
+const db = require('../db')
+const app = require('../index')
+const Sock = db.model('sock')
+
+describe('Socks route', () => {
+  beforeEach(() => {
+    return db.sync({force: true})
+  })
+
+  describe('GET all Adult Socks', () => {
+    const sandleSock = 'sandle sock'
+
+    //price might fail Sequelize Validation if:
+    //your model is a Decimal instead of an Integer (in cents)
+
+    beforeEach(() => {
+      return Sock.create({
+        name: sandleSock,
+        price: 450,
+        isAdult: true,
+        sizes: [7,12]
+      })
+    })
+
+    it('filters for Adult Socks', async () => {
+      const res = await request(app)
+        .get('/api/socks?isAdult=true')
+        .expect(200)
+
+      expect(res.body).to.be.an('array')
+      expect(res.body[0].name).to.be.equal(sandleSock)
+    })
+  })
+
+  describe('GET all Kid Socks', () => {
+    const caterpillarSock = 'caterpillar toes baby'
+
+    beforeEach(() => {
+      return Sock.create({
+        name: caterpillarSock,
+        price: 250,
+        isAdult: false,
+        sizes: [7,12]
+      })
+    })
+
+    it('filters for Kid Socks', async () => {
+      const res = await request(app)
+        .get('/api/socks?isAdult=false')
+        .expect(200)
+
+      expect(res.body).to.be.an('array')
+      expect(res.body[0].name).to.be.equal(caterpillarSock)
+    })
+  })
+}) 
+


### PR DESCRIPTION
## What did you change?
 - Created a file 'server/api/socks.spec.js' for testing our /socks routes
 - Added two routes: one for filtering Adult Socks, and one for filtering Kid Socks

## What did it fix or what is now possible because of your change?
 - Those two tests are currently passing
 - Initial structure is in place for edge cases, specific features, etc

## Is there anything that needs to happen as a result of this change?
-No, just be aware that the Sock Price expects a type of Sequelize.INTEGER, not Sequelize.DECIMAL

## Are there any questions you had about the implementation or other possibilities you'd like the reviewers to consider?


=(^.^)=


