### PR TITLE
task: related socks populate in single sock page

### DIFF
--- a/client/components/adult-socks.js
+++ b/client/components/adult-socks.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import {connect} from 'react-redux'
 import {fetchAdultSocks} from '../store/socks'
-import {Link} from 'react-router-dom'
-import CategoryMenu from './category-menu';
+import CategoryMenu from './category-menu'
 import {SockList} from './sock-list'
 
 class AdultSocks extends React.Component {
@@ -13,7 +12,7 @@ class AdultSocks extends React.Component {
     const {adultSocks} = this.props
     return (
       <div className="flex column center container-space-around">
-      <CategoryMenu onClick={() => {}}/>
+        <CategoryMenu onClick={() => {}} />
         <div className="flex center category-header">
           <h1>Adults Sock</h1>
         </div>

--- a/client/components/related-socks.js
+++ b/client/components/related-socks.js
@@ -1,24 +1,75 @@
 import React from 'react'
+import {connect} from 'react-redux'
+import {fetchAdultSocks} from '../store/socks'
+import {Link} from 'react-router-dom'
 
-export const SizeDropdown = props => {
-  const {sock} = props
+const shuffle = a => {
+  let newArr = a.slice()
 
-  return (
-    <div className="flex wrap">
-      <h3 className="slight-padding">Select Size:</h3>
-      <div className="center" id="size-dropdown">
-        <div>
-          <label htmlFor="size-select" />
-          <select name="size-select" id="size-select" defaultValue="--">
-            <option disabled>--</option>
-            {sock.sizes.map((size, i) => (
-              <option key={i}>
-                {size} M - {size - 3} W
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-    </div>
-  )
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[newArr[i], newArr[j]] = [newArr[j], newArr[i]]
+  }
+  return newArr
 }
+
+const includesAny = (arr1, arr2) => {
+  const longArr = arr1.length >= arr2.length ? arr1 : arr2
+  const shortArr = arr1.length < arr2.length ? arr1 : arr2
+  for (let elem of shortArr) {
+    if (longArr.includes(elem)) return true
+  }
+  return false
+}
+
+class RelatedSocks extends React.Component {
+  async componentDidMount() {
+    await this.props.getAdultSocks()
+  }
+
+  render() {
+    const {adultSocks, mainSock} = this.props
+    let randomRelatedSocks = shuffle(
+      adultSocks.filter(
+        sock =>
+          sock.id !== mainSock.id &&
+          includesAny(sock.categories, mainSock.categories)
+      )
+    ).slice(0, 6)
+
+    return randomRelatedSocks.length ? (
+      <div>
+        <h3 id="customers-also-liked">Our Customers Also Liked:</h3>
+        <ul className="flex space-evenly no-padding">
+          {randomRelatedSocks.map(sock => (
+            <Link
+              className="no-decoration black"
+              onClick={window.scrollTo(0, 0)}
+              key={sock.id}
+              to={`/socks/${sock.id}`}
+            >
+              <li className="center related-sock-image" key={sock.id}>
+                <img className="related-sock-image" src={sock.photos[0]} />
+                <p id="related-sock-name" className="wrap-word center">
+                  {sock.name.toUpperCase()}
+                </p>
+              </li>
+            </Link>
+          ))}
+        </ul>
+      </div>
+    ) : (
+      <p>No related socks in stock</p>
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  adultSocks: state.socks
+})
+
+const mapDispatchToProps = {
+  getAdultSocks: fetchAdultSocks
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(RelatedSocks)

--- a/client/components/single-sock.js
+++ b/client/components/single-sock.js
@@ -1,9 +1,9 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {fetchSock} from '../store/socks'
-import {Link} from 'react-router-dom'
 import {SizeDropdown} from './size-dropdown'
 import {QuantityDropdown} from './quantity-dropdown'
+import RelatedSocks from './related-socks'
 
 class SingleSock extends Component {
   async componentDidMount() {
@@ -21,14 +21,16 @@ class SingleSock extends Component {
       <div>no sock</div>
     ) : (
       <div>
-        <div className="flex row">
+        <div className="flex">
           <br />
           <div>
             <img id="single-page-photo" src={sock.photos[0]} />
           </div>
           <br />
           <div>
-            <h1 className="slight-padding single-page-label">{sock.name.toUpperCase()}</h1>
+            <h1 className="slight-padding single-page-label">
+              {sock.name.toUpperCase()}
+            </h1>
             <p className="slight-padding" id="single-price">{`$${(
               sock.price / 100
             ).toFixed(2)}`}</p>
@@ -46,31 +48,22 @@ class SingleSock extends Component {
             )}
           </div>
         </div>
-        {!sock.categories ? (
-          <div />
-        ) : (
-          <div>
-            <h3>Categories:</h3>
-            <div>
-              {sock.categories.map((category, i) => {
-                const path = `/socks/category/${category}`
-                return (
-                  <div key={i}>
-                    <Link to={path}>{category}</Link>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-        )}
+        {!sock.categories ? <div /> : <RelatedSocks mainSock={sock} />}
       </div>
     )
   }
 }
 
-const mapStateToProps = state => ({
-  sock: state.socks[0]
-})
+const mapStateToProps = (state, ownProps) => {
+  return {
+    sock:
+      state.socks.length === 1
+        ? state.socks[0]
+        : state.socks.find(
+            item => item.id === Number(ownProps.match.params.sockId)
+          )
+  }
+}
 
 const mapDispatchToProps = dispatch => ({
   getSock: id => dispatch(fetchSock(id))

--- a/public/style.css
+++ b/public/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: 'Raleway', sans-serif;
-  margin:0;
+  margin: 0;
   font-size: 16px;
   letter-spacing: 2px;
   word-spacing: 2px;
@@ -32,37 +32,47 @@ form div {
   text-align: center;
 }
 
-.flex{
+.flex {
   display: flex;
 }
 
-.flex-start{
+.flex-start {
   justify-content: flex-start;
 }
 
-.row{
+.row {
   flex-direction: row;
 }
 
-.column{
+.column {
   flex-direction: column;
 }
 
-.wrap{
+.wrap {
   flex-wrap: wrap;
 }
 
-.container-space-around{
+.container-space-around {
   justify-content: space-around;
 }
 
-.slight-padding{
-  padding: 5px 10px 0px 20px;
-  height: 30px;
+.space-evenly {
+  justify-content: space-evenly;
 }
 
+.slight-padding {
+  padding: 5px 10px 0px 20px;
+}
 
-.category-header{
+.wrap-word {
+  word-wrap: break-word;
+}
+
+.no-padding {
+  padding: 0px;
+}
+
+.category-header {
   background: rgb(227, 228, 164);
   background-image: url('https://d2gg9evh47fn9z.cloudfront.net/800px_COLOURBOX9878837.jpg');
   opacity: 0.75;
@@ -72,16 +82,21 @@ form div {
   width: 99vw;
   border-top: 1em solid rgb(236, 236, 236);
   border-bottom: 1em solid rgb(236, 236, 236);
-
 }
 
-.sock-image{
+.sock-image {
   width: 20vw;
   height: auto;
   padding-top: 2em;
 }
 
-.sock-display-div{
+.related-sock-image {
+  width: 13vw;
+  height: auto;
+  padding-top: 1em;
+}
+
+.sock-display-div {
   background: white;
   border-bottom: 1.5em solid rgb(236, 236, 236);
   padding-bottom: 0.8em;
@@ -91,70 +106,70 @@ form div {
   display: flex;
   width: 99vw;
   justify-content: space-between;
-  background-color: #26777F;
+  background-color: #26777f;
 }
 
 .top-header > div {
   margin: 10px 5px;
 }
 
-.top-header-link{
-  margin-right:15px;
+.top-header-link {
+  margin-right: 15px;
   font-weight: bold;
-  color:white;
+  color: white;
   text-decoration: none;
   font-size: 1.25em;
 }
 
-.bottom-header{
+.bottom-header {
   display: flex;
   width: 99vw;
   justify-content: center;
   border-bottom: 1px solid black;
-  background-color: #A8F6FF;
+  background-color: #a8f6ff;
 }
 
-.no-decoration{
+.no-decoration {
   text-decoration: none;
   list-style-type: none;
 }
 
-.black{
+.black {
   color: black;
 }
 
-.hover-light:hover{
+.hover-light:hover {
   text-shadow: 0px 0px 3px white;
 }
 
-.lower-link{
-  margin:0;
-  padding:15px;
+.lower-link {
+  margin: 0;
+  padding: 15px;
   width: 75px;
   text-align: center;
 }
 
-.lower-link:hover{
+.lower-link:hover {
   background-color: rgba(255, 255, 255, 0.5);
 }
 
-.category-menu-item{
-  color:white;
+.category-menu-item {
+  color: white;
   text-align: center;
-  padding:10px;
+  padding: 10px;
 }
 
-.vert-center{
-  position:relative;
-  top:50%;
+.vert-center {
+  position: relative;
+  top: 50%;
   transform: translateY(-50%);
 }
 
-.white{
-  color:white;
+.white {
+  color: white;
 }
 
-.single-page-label{
+.single-page-label {
   text-decoration: underline;
 }
 
@@ -168,33 +183,33 @@ form div {
   text-shadow: 0px 0px 5px black;
 }
 
-#logo-text:hover{
+#logo-text:hover {
   text-shadow: 0px 0px 5px white;
 }
 
-#nav-photo{
-  margin-right:15px;
+#nav-photo {
+  margin-right: 15px;
   width: 75px;
   height: 75px;
   border-radius: 50%;
 }
 
-#nav-photo:hover{
+#nav-photo:hover {
   box-shadow: 0px 0px 10px white;
 }
 
-#user-icon{
-  margin-right:15px;
+#user-icon {
+  margin-right: 15px;
   width: 75px;
   height: 75px;
   border-radius: 50%;
-  background-color: #26777F;
+  background-color: #26777f;
   border: none;
   outline: 0;
-  box-shadow: none!important;
+  box-shadow: none !important;
 }
 
-#user-dropdown{
+#user-dropdown {
   display: flex;
   flex-direction: column;
   background-color: white;
@@ -205,7 +220,7 @@ form div {
   z-index: 1;
 }
 
-#user-dropdown > li{
+#user-dropdown > li {
   flex-direction: row;
   align-self: flex-end;
   padding: 5px;
@@ -214,67 +229,75 @@ form div {
   bottom: 10px;
 }
 
-#below-user-icon{
+#below-user-icon {
   font-size: 12px;
   position: relative;
   left: 10px;
   margin: 0;
 }
 
-#below-user-icon:hover{
+#below-user-icon:hover {
   text-shadow: 0px 0px 10px white;
 }
 
-#four04-text{
+#four04-text {
   font-size: 16em;
   margin: 16px;
   text-align: center;
 }
 
-#lost-four04{
+#lost-four04 {
   text-align: center;
   font-size: 2em;
 }
 
-#four04-home{
+#four04-home {
   font-size: 1.5em;
   text-align: center;
 }
 
-#four04-link{
+#four04-link {
   border: 1px solid black;
   padding: 10px;
-  box-shadow: 0px 0px 3px black
+  box-shadow: 0px 0px 3px black;
 }
 
-#four04-link:hover{
+#four04-link:hover {
   text-shadow: 0px 0px 3px black;
 }
 
-#size-dropdown{
+#size-dropdown {
   padding: 22px 0px 0px 10px;
   height: 30px;
 }
 
-#size-select{
+#size-select {
   width: 150px;
   font-size: 1.2em;
   text-align: center;
 }
 
-#categorys-menu{
-  background-color:#26777F;
+#categorys-menu {
+  background-color: #26777f;
   display: flex;
   justify-content: space-around;
   flex-grow: inherit;
 }
 
-#single-page-photo{
-  padding: 20px;
+#single-page-photo {
+  padding: 20px 150px;
   height: 475px;
   width: 475px;
 }
 
-#single-price{
+#single-price {
   font-size: 1.2em;
+}
+
+#customers-also-liked {
+  padding-top: 30px;
+}
+
+#related-sock-name:hover {
+  text-shadow: 0px 0px 0.5px black;
 }


### PR DESCRIPTION
## What did you change?
- single-sock.js, related-socks.js, adult-sock.js, style.css

## What did it fix or what is now possible because of your change?
- Now populates up to 6 related socks based on whether or not it has at least one matching category with the chosen single sock

## Is there anything that needs to happen as a result of this change?
- We need a thunk for all socks. Our related socks are currently showing just the adult socks and there is not much of a way around this with how our store is designed.
- Besides that, single sock page is about good besides add to cart button.

## Are there any questions you had about the implementation or other possibilities you'd like the reviewers to consider?



=(^.^)=


