### PR TITLE
feat: route/thunk for all socks as well as query for kid or adult socks

### DIFF
--- a/client/components/related-socks.js
+++ b/client/components/related-socks.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {connect} from 'react-redux'
-import {fetchAdultSocks} from '../store/socks'
+import {fetchAllSocks} from '../store/socks'
 import {Link} from 'react-router-dom'
 
 const shuffle = a => {
@@ -24,13 +24,13 @@ const includesAny = (arr1, arr2) => {
 
 class RelatedSocks extends React.Component {
   async componentDidMount() {
-    await this.props.getAdultSocks()
+    await this.props.getAllSocks()
   }
 
   render() {
-    const {adultSocks, mainSock} = this.props
+    const {socks, mainSock} = this.props
     let randomRelatedSocks = shuffle(
-      adultSocks.filter(
+      socks.filter(
         sock =>
           sock.id !== mainSock.id &&
           includesAny(sock.categories, mainSock.categories)
@@ -65,11 +65,11 @@ class RelatedSocks extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  adultSocks: state.socks
+  socks: state.socks
 })
 
 const mapDispatchToProps = {
-  getAdultSocks: fetchAdultSocks
+  getAllSocks: fetchAllSocks
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(RelatedSocks)

--- a/client/store/socks.js
+++ b/client/store/socks.js
@@ -65,6 +65,14 @@ export const fetchSock = id => async dispatch => {
   }
 }
 
+export const fetchAllSocks = () => async dispatch => {
+  try {
+    const {data} = await axios.get(`/api/socks/`);
+    dispatch(gotSocks(data));
+  } catch (error) {
+    console.error(error);
+  }
+}
 
 // REDUCER
 

--- a/server/api/socks.js
+++ b/server/api/socks.js
@@ -6,9 +6,13 @@ const Op = Sequelize.Op
 router.get('/', async (req, res, next) => {
   try {
     let socks = []
-    req.query.isAdult === 'true'
-    ? socks = await Sock.findAll({where: {isAdult: true}})
-    : socks = await Sock.findAll({where: {isAdult: false}})
+    if(req.query.isAdult === 'true'){
+      socks = await Sock.findAll({where: {isAdult: true}})
+    } else if (req.query.isAdult === 'false'){
+      socks = await Sock.findAll({where: {isAdult: false}})
+    } else {
+      socks = await Sock.findAll()
+    }
     res.json(socks)
   } catch(err) {
     next(err)


### PR DESCRIPTION
## What did you change?
in socks route and socks router, create ability to return all sock if query isAdult isn't provided. 

## What did it fix or what is now possible because of your change?
can get all sock from getAllSocks thunk when necessary.

## Is there anything that needs to happen as a result of this change?
double-check I didn't break anything in the parts you know well. Otherwise, no. 

## Are there any questions you had about the implementation or other possibilities you'd like the reviewers to consider?
no

=(^.^)=


