### PR TITLE
Cart order sync

### DIFF
--- a/client/components/order-button.js
+++ b/client/components/order-button.js
@@ -8,7 +8,8 @@ class OrderButton extends Component {
     evt.preventDefault();
     try {
       const userId = this.props.user.id
-      await this.props.addOrder(userId)
+      const sockId = this.props.sockId
+      await this.props.addOrder(userId, sockId)
     } catch(err) {
         console.log(err);
     }
@@ -22,12 +23,13 @@ class OrderButton extends Component {
   }
 };
 
-const mapStateToProps = state => ({
-  user: state.user
+const mapStateToProps = (state, ownProps)=> ({
+  user: state.user,
+  sockId: ownProps.sockId
 });
 
 const mapDispatchToProps = dispatch => ({
-  addOrder: id => dispatch(postOrder(id))
+  addOrder: (userId, sockId) => dispatch(postOrder(userId, sockId))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(OrderButton);

--- a/client/components/order-list.js
+++ b/client/components/order-list.js
@@ -6,8 +6,7 @@ import axios from 'axios';
 
 class OrderList extends Component {
 
-  async componentDidMount () {
-    
+  async componentDidMount () { 
     try {
       const userId = Number(this.props.match.params.userId)
       await this.props.getOrders(userId)

--- a/client/components/single-sock.js
+++ b/client/components/single-sock.js
@@ -43,7 +43,7 @@ class SingleSock extends Component {
               <div>
                 <SizeDropdown sock={sock} />
                 <QuantityDropdown />
-                <OrderButton />
+                <OrderButton sockId={sock.id}/>
               </div>
             ) : (
               <p>Out of Stock :(</p>

--- a/client/components/sock pics.md
+++ b/client/components/sock pics.md
@@ -1,0 +1,326 @@
+unicorn 'http://static.shoplightspeed.com/shops/603601/files/003179864/rainbow-unicorn-kid-socks.jpg'
+
+donut 'http://static.shoplightspeed.com/shops/603601/files/003179890/sprinkle-donuts-kid-socks.jpg'
+
+space 'https://www.fightingsawks.com/uploads/2/9/2/5/29258291/s865610946843620892_p201_i2_w1536.jpeg'
+
+pizza 'https://cdn.shopify.com/s/files/1/0234/4461/products/pizza_kids_socks_green_socksmith_2048x.jpg?v=1525897606'
+
+owl 'https://cdn.shopify.com/s/files/1/0234/4461/products/owl_night_kids_crew_socks_blue_socksmith_cute_2048x.jpg?v=1508883697'
+
+monster 3 pack 'https://i.ebayimg.com/images/g/FzkAAOxy9X5TYPzR/s-l300.jpg'
+
+rainbow stripe 'http://www.tinysoles.com/images/P/Country%20Kids%20Rainbow%20Stripe%20Sock%20Coral%20300.jpg'
+
+orchid 'http://www.tinysoles.com/images/P/Country%20Kids%20Rainbow%20Stripe%20Sock%20Orchid%20300.jpg'
+
+candy shop 'https://www.crazysockscollection.com/wp-content/uploads/2017/08/crazy-socks-collection-candy-shop-Children-Socks.jpg'
+
+toy story 'https://images.vans.com/is/image/Vans/X4JKY6-HERO?$583x583$'
+
+5 pack striped casual 'https://asset1.cxnmarksandspencer.com/is/image/mands/SD_04_T64_4666B_ZZ_X_EC_0?$PLP_PRODUCT_IMAGE$'
+
+cookies and milk 'https://www.crazysockscollection.com/wp-content/uploads/2017/08/crazy-socks-collection-cookies-and-milk-kids-socks.jpg'
+
+cat queen 'http://cdn8.bigcommerce.com/s-in5je/images/stencil/1280x1280/products/4769/13247/practically-purrfect-kids-socks__94255.1531353805.jpg?c=2&imbypass=on'
+
+taco socks 'https://cdn.shopify.com/s/files/1/1670/8729/products/socksmith-socks-kids-4-7-years-purple-green-tacos-kids-socks-750035697684_600x600.png?v=1523572839'
+
+assorted 3-pack 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSMdH8D9tG-QCZDq36M3AQ6mda4IXPCvYydG41k0EHl-2nJviFM'
+
+low cut athletic 'https://s7d2.scene7.com/is/image/dkscdn/16UARY6PKRSSTRLCYAPA'
+
+no-show running 'https://images-na.ssl-images-amazon.com/images/I/81s1yRozE-L._SX522_.jpg'
+
+athletic 3-pack 'https://image.dhgate.com/0x0/f2/albu/g1/M01/E9/3D/rBVaGForwSOAEwKsAAFPt7f4bIo193.jpg'
+
+athletic 3-pack low cut 'https://cdn.shopify.com/s/files/1/1260/4249/products/gm-358695a.main_large.jpg?v=1528821758'
+
+mini crochet lace 'http://cdn3.volusion.com/kzkqm.kxjqh/v/vspfiles/photos/B598-2.jpg?1329346265'
+
+
+3 pack dress brown 'http://cdn3.volusion.com/kzkqm.kxjqh/v/vspfiles/photos/5120A-2.jpg?1329346265'
+
+grey robot dress 'https://cdn1.boldsocks.com/wp-content/uploads/product-photography/24169SITM-JUNIOR-Gray-Robot-Kids-Dress-Socks-Sock-it-to-Me/images/24169SITM-JUNIOR-Gray-Robot-Kids-Dress-Socks-Sock-it-to-Me27.jpg'
+
+green football field dress 'https://cdn1.boldsocks.com/wp-content/uploads/product-photography/24188SITM-JUNIOR-Green-Football-Field-Kids-Dress-Socks-Sock-it-to-Me/images/24188SITM-JUNIOR-Green-Football-Field-Kids-Dress-Socks-Sock-it-to-Me09.jpg'
+
+3 pack dress black 'https://www.jcrew.com/s7-img-facade/G7270_BK0001?fmt=jpeg&qlt=90,0&resMode=sharp&op_usm=.1,0,0,0&wid=200&hei=200'
+
+einstein dress 'https://cdn1.boldsocks.com/wp-content/uploads/product-photography/24213SS-7-10Y-Black-Einstein-Genius-Kids-Dress-Socks-Socksmith/images/24213SS-7-10Y-Black-Einstein-Genius-Kids-Dress-Socks-Socksmith09.jpg'
+
+3 pack lace dress 'https://sc02.alicdn.com/kf/HTB1K_MNJVXXXXb.XXXXq6xXFXXXg.jpg'
+
+pizza dress 'http://www.babesinbookland.com/wp-content/uploads/2018/07/over-the-calf-dress-socks-gray-yellow-pizza-men-s-dress-socks-statement-sockwear-of-over-the-calf-dress-socks-1.jpg'
+
+white lace dress 'http://cdn3.volusion.com/kzkqm.kxjqh/v/vspfiles/photos/5251-1.jpg?1359952834'
+
+polka dot dress 'https://cdn.shopify.com/s/files/1/1210/2908/products/CRKS1-DOT009-7043_grande.jpg?v=1520529314'
+
+soccer dress 'https://cdn.shopify.com/s/files/1/1210/2908/products/CRKS1-SPR004-7142_grande.jpg?v=1520529650'
+
+white dress 'https://i.pinimg.com/originals/3a/bc/b4/3abcb483af53cf0bbd961fd27d9df8ee.jpg'
+
+3 pk hearts dress 'http://static.shoplightspeed.com/shops/602409/files/000420132/380x275x2/worlds-softest-childrens-socks.jpg'
+
+3 pack xmas dress 'https://i.pinimg.com/236x/76/3b/76/763b7622c8cac7decf97703a5187da6e--kids-socks-cotton-socks.jpg'
+
+3 pk dress marvel 'https://images-na.ssl-images-amazon.com/images/I/81EX1tbJnKL._SY879_.jpg'
+
+no broccoli funny 'http://www.fightingsawks.com/uploads/2/9/2/5/29258291/s865610946843620892_p189_i1_w411.jpeg'
+
+pug party funny  'https://cdn.shopify.com/s/files/1/0234/4461/products/pug_socks_for_kids_socksmith_blue_cute_2048x.jpg?v=1525898298'
+
+sock person funny 'https://cdn.shopify.com/s/files/1/0819/4135/products/Funny-Kids-Socks-Brad-Feet_480x_2x_d91d0b0f-c91e-415a-8b57-1ac7ebfed553.jpg?v=1504476016'
+
+despicable me pop culture 'https://1805647376.rsc.cdn77.org/wp-content/uploads/Ankle-Funny-Socks-for-Kids5-500x500.jpg'
+
+green funny face 'https://i.ebayimg.com/images/g/bQUAAOSwIWZZfxN2/s-l300.jpg'
+colors^^^>>>vvvv
+orange funny face 'https://i.ebayimg.com/images/g/L-MAAOSwZs1Zfxqa/s-l300.jpg'
+
+white ankle ath 'https://underarmour.scene7.com/is/image/Underarmour/1240845-100_S?scl=1&fmt=jpg&qlt=70&wid=1064&hei=1240&size=958,1116&cache=on,off&bgc=f0f0f0&resMode=sharp2'
+
+spider man casual 'https://gsxtr.com/i/pr/accessori-vans-vans-x-marvel-sock-heather-grey-146916-674-1.jpg'
+
+cartoon superhero purple 'https://i.pinimg.com/236x/38/a7/be/38a7bee267cf47729e81749e0eb1dfc3--cute-cartoon-characters-batman-clothing.jpg'
+
+looney tunes 'https://shop.r10s.jp/mm-pop/cabinet/r201505-4/sm-wblt300.jpg'
+
+ looney tunes 5 pack 'http://lp2.hm.com/hmgoepprod?set=source[/d5/ab/d5ab4f9ec6c5ffdf4a9184c0868fe3eee967079f.jpg],origin[dam],category[kids_boy8y_socks],type[DESCRIPTIVESTILLLIFE],res[s],hmver[1]&call=url[file:/product/main]'
+ *OR* 
+ 'http://lp2.hm.com/hmgoepprod?set=source[/b2/d1/b2d1d942c3187072e1dd6bf94c82f78e310c127c.jpg],origin[dam],category[kids_boy8y_socks],type[DESCRIPTIVESTILLLIFE],res[s],hmver[1]&call=url[file:/product/main]'
+
+-----------
+
+black dress 'https://images-na.ssl-images-amazon.com/images/I/81kOz-T75mL._UL1500_.jpg'
+
+3 pack dress 'http://dimg.dillards.com/is/image/DillardsZoom/zoom/calvin-klein-mercerized-cotton-neat-crew-dress-socks-3-pack/05138926_zi_black.jpg'
+
+red/grey stripe dress 'https://cdn.shopify.com/s/files/1/1079/1374/products/V1327-Black_large.JPG?v=1492460097'
+
+purple stripe dress 'https://cdn.shopify.com/s/files/1/1631/8771/products/MG_7726h_2000x.jpg?v=1494454894'
+
+blue stripe dress 'https://cdn.shopify.com/s/files/1/1079/1374/products/V1326-Turquoise_large.JPG?v=1492459851'
+
+3 pack brown dots 'http://www.ellareidcreative.com/images/611/353607_965.jpg'
+
+5 pack assorted dress 'https://brobible.files.wordpress.com/2017/12/patterned-socks.jpg?quality=90&w=650'
+
+purple yellow diamond dress 'https://www.tiemart.com/media/catalog/product/cache/c687aa7517cf01e65c009f6943c2b1e9/d/a/dark-purple-and-gold-argyle-socks_1.jpg'
+
+orange stripe dress 'https://cdn.shopify.com/s/files/1/0027/3382/products/LC2_3060_large.jpg?v=1521552461'
+
+5 pack assorted dress 2 'https://ae01.alicdn.com/kf/HTB1HH7oRVXXXXXQapXXq6xXFXXXT/10-Pairs-Lot-Plus-Size-Black-White-Men-s-Dress-Socks-Autumn-Winter-Long-High-Thermal.jpg_640x640.jpg'
+
+guitar dress 'https://cdn.shopify.com/s/files/1/0673/5967/products/IMG_2749.jpg?v=1511712445'
+
+edvard munch 'the scream' --- 'https://www.meetsocks.com/wp-content/uploads/beloved-oil-painting-custom-dress-socks-men-shouting.jpg'
+
+black grey diamond dress 'https://cdn.shopify.com/s/files/1/1260/4249/products/us-ad0a.main_large.jpg?v=1530212440'
+
+ankle dress 'http://p.globalsources.com/IMAGES/PDT/BIG/086/B1159013086.jpg'
+
+la di da cat dress 'https://cdn1.boldsocks.com/wp-content/uploads/2017/03/31123531/23866-Grey-Black-La-di-da-Cat-Womens-Dress-Socks-BlueQ01.jpg'
+
+penguin dress 'https://s-media-cache-ak0.pinimg.com/originals/aa/64/ab/aa64abb96befd1a2cf47d7a386d2138d.jpg'
+
+3 pack dotted dress 'https://brobible.files.wordpress.com/2017/12/polka-dot-socks.jpg?quality=90&w=650'
+
+3 pack brown dress'https://target.scene7.com/is/image/Target/51770976?wid=488&hei=488&fmt=pjpeg'
+
+
+casual outdoor athletic tube 'https://s7d2.scene7.com/is/image/academy/10249104?wid=500&hei=500'
+
+casual/athletic grey polar expedition sock 'http://www.lhasascotland.co.uk/images/category_42/Baffin%20Charcoal%20Baffin%20Polar%20Expedition%20Sock%20JH45285.jpg'
+
+3 pack casual/dress 'http://www.solaxsocks.com/uploadfiles/pictures/product/20170112155741_3057.jpg'
+
+white tube casual/athletic 'http://www.kyle-rebecca.com/images/shz15/M-197000-111279.jpg'
+
+
+
+
+3 pack casual/athletic 'https://www.angelknitting.com/wp-content/uploads/2017/09/men-ankle-casual-socks-2.jpg'
+
+stripe casual/dress 'http://www.cn-sock.com/wp-content/uploads/2016/08/CGMS16007.jpg'
+
+3 pack flower pattern 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTOdmBWykj0HEgkTF-6LyTNKcBUV01HjD9YhwC71l8cDqh1Gz9f'
+
+pug crew 'https://cdn.shopify.com/s/files/1/0234/4461/products/pugs-crew-socks-womens-blue_2048x.jpg?v=1478893002'
+
+3 pack casual 'https://ae01.alicdn.com/kf/HTB1Wim_JFXXXXcfXVXXq6xXFXXXQ/One-Pairs-Free-shipping-Classic-black-white-gray-solid-color-socks-brand-quality-men-s-socks.jpg'
+
+3 pack no-show casual 'https://ae01.alicdn.com/kf/HTB1p.LXLpXXXXb5aXXXq6xXFXXXY/10Pcs-10Pairs-Womens-White-Black-Grey-Ankle-Socks-Net-Hole-style-Breathable-Trainer-Liner-Ankle-Socks.jpg'
+
+3 pack casueal ankel 'http://www.dreamproducts.com/media/catalog/product/cache/1/image/600x600/602f0fa2c1f0d1ba5e241f914e856ff9/u/l/ultimate_diabetic_socks_tall_all_colors.jpg'
+
+3 pack ankle casual 'https://noskivkorobke.ru/wa-data/public/shop/products/29/22/2229/images/357/357.350.jpg'
+
+blue bermuda casual 3 pack 'http://s7d9.scene7.com/is/image/JCPenney/DP0409201417032914M'
+
+striped casual 'http://www.cn-sock.com/wp-content/uploads/2016/08/CGMS16007.jpg'
+
+lo cut ath 'https://workingperson.com/media/catalog/product/cache/1/image/400x/9df78eab33525d08d6e5fb8d27136e95/i/m/image_66230.jpg'
+
+ankle athletic/casual 'https://www.innovateistore.com/resize/Shared/images/dr-comfort-ankle-socks-3.jpg?bw=1000&w=1000&bh=1000&h=1000'
+
+nike athletic 'https://hockeymonkey.nexcesscdn.net/media/catalog/product/cache/3/small_image/600x/9df78eab33525d08d6e5fb8d27136e95/n/i/nike-socks-nikegrip-strike-cushioned-crew-unisex-football-senior.jpg'
+
+batman ath 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQksL4HQD-hYsei-etlL36gEoGuPJTM_PQEoUBG3GssUYe4UWHm'
+
+3 pk casual 'http://www.rhivaangroup.com/im/shock/divya-garments-raj-nagar-ghaziabad-75zb.jpg'
+
+batman casual/dress 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-dc-comics-batman-large-all-over-print-socks-1_2048x@2x.jpg?v=1500546893'
+
+3 pack nike  'https://cdn.trendhunterstatic.com/thumbs/hyper-elite-socks.jpeg'
+
+ankle athletic pink 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRehyTQeBiQlkH9pf-a6WTadkj34X9Q5YMsb4Gdwxr9-OU6OzUPg'
+
+no show ath black 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS86E8ruO92e0i126htKKaeqddcL_NR3109lB9VaAVre6irMk57Bw'
+
+no show ath white grey 'https://images-na.ssl-images-amazon.com/images/I/81PzeSS2EgL._SX425_.jpg'
+
+3 pack under armor no show white 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS6ncHCwcofgaqm6ouYEQjhI4fE2Cx_4yHeLe7ED72NQawFm_3n'
+
+3 pack pink under armor no sho 'https://underarmour.scene7.com/is/image/Underarmour/1264048-967_GROUP?scl=1&fmt=jpg&qlt=70&wid=1064&hei=1240&size=958,1116&cache=on,off&bgc=f0f0f0&resMode=sharp2'
+
+3 pk adidas 'https://s7d2.scene7.com/is/image/academy/10399663?wid=500&hei=500'
+
+3pk asssortedd neon no show ath 'https://i.ebayimg.com/images/g/x1cAAOSwE0ZarAQS/s-l300.png'
+
+nike no sho ath 'https://i0.wp.com/whattowearfor.org/wp-content/uploads/2016/09/word-image.jpeg?resize=500%2C435'
+
+pink/white sun athletic 'http://cdn3.bigcommerce.com/s-mxtfmh/product_images/uploaded_images/best-womens-athletic-socks.jpg'
+
+3 pak ath 'http://www.snzglobal.com/wp-content/uploads/2015/11/RRU1099-WH.jpg'
+
+3 pk ankle adidas 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTR-KfOKgVLkYTij55RHhyhFVlB6TJPspYqD1mOWQlz8k_YfFoD'
+
+3 pk marvel 'http://www.thinkgeek.com/images/products/zoom/2056_marvel_ladies_character_boots_knee_high_3_pack.jpg'
+
+3 pk marvel 2 'https://images.sportsdirect.com/images/products/41802090_l.jpg'
+
+deadpool 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-marvel-deadpool-large-all-over-print-socks-1_2048x@2x.jpg?v=1500546931'
+
+black panther 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-marvel-black-panther-waterprint-socks-4_580x@2x.jpg?v=1521636245'
+
+punisher 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ944bHQMmyQ5DPlYC8rXh5x3bCMbxSpLS13WE5EXeNHEnXSkSfBQ'
+
+venom 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-marvel-venom-360-socks-1_2048x@2x.jpg?v=1515386607'
+
+spider 'gwen' --- 'http://static.shoplightspeed.com/shops/602409/files/001173849/marvel-spider-gwen-crew-socks.jpg'
+
+xmen 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-fdngXD1kMQXDHh0Nl2syTdyJO6itdbK6vrlbJb0dQ1NH-LfY1g'
+
+marvel no sho 3 pack 'https://www.tillys.com/dw/image/v2/BBLQ_PRD/on/demandware.static/-/Sites-master-catalog/default/dw2aabb41e/tillys/images/catalog/1000x1000/324908957.jpg?sw=539&sh=693&sm=fit'
+
+ironman dress 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-marvel-iron-man-cartoon-sketch-socks-1_2048x@2x.jpeg?v=1527969873'
+
+ironman 'https://images-na.ssl-images-amazon.com/images/I/716n%2BJB4U6L._UX385_.jpg'
+
+spderman 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-marvel-spider-man-suit-up-athletic-socks-1_2048x@2x.jpg?v=1500547132'
+
+3 pk spiderman 'http://www.thinkgeek.com/images/products/zoom/f0f1_marvel_superhero_socks.jpg'
+
+batman 'http://www.thinkgeek.com/images/products/zoom/f0f1_marvel_superhero_socks.jpg'
+
+xmen storm 'https://cdn1.boldsocks.com/wp-content/uploads/product-photography/23936-Black-Grey-X-Men-Storm-Sublimated-Mens-Casual-Socks-BIOWORLD/images/23936-Black-Grey-X-Men-Storm-Sublimated-Mens-Casual-Socks-BIOWORLD13.jpg'
+
+simpsons dress/casual homer dounut 'https://www.tillys.com/dw/image/v2/BBLQ_PRD/on/demandware.static/-/Sites-master-catalog/default/dwf193d7c8/tillys/images/catalog/1000x1000/274145100.jpg?sw=539&sh=693&sm=fit'
+
+bart simpson 'https://www.tillys.com/dw/image/v2/BBLQ_PRD/on/demandware.static/-/Sites-master-catalog/default/dw2d5f282b/tillys/images/catalog/1000x1000/263196149.jpg?sw=539&sh=693&sm=fit'
+
+kyle sp 'https://www.thesnowboardshop.co.uk/images/burton-weekend-socks-south-park-2-pack-p4523-10282_image.jpg'
+
+mr meeseeks rick and morty 'https://di2ponv0v5otw.cloudfront.net/posts/2018/09/06/5b91a5bd4ab633d1fac4735b/m_5b91a5c8f30369dcf00f1ba7.jpg'
+
+pickle rick 'https://skateparkoftampa.com/spot/productimages/colors/11_79855.jpg'
+
+pickle rick 2 'https://www.tillys.com/dw/image/v2/BBLQ_PRD/on/demandware.static/-/Sites-master-catalog/default/dw30ce786f/tillys/images/catalog/1000x1000/332758500.jpg?sw=539&sh=693&sm=fit'
+
+cactaur final fantasy 'https://www.artistshot.com/assets/images/admin/product_design/2004674/cactuar-final-fantasy-socks-420x420.jpg'
+
+hogwarts 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-harry-potter-hogwarts-vertical-socks-1_2048x@2x.jpg?v=1504532579'
+
+star trek 3d 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-star-trek-spock-3d-socks-1_2048x@2x.jpg?v=1496598472'
+
+mario mushroom 'https://www.tillys.com/dw/image/v2/BBLQ_PRD/on/demandware.static/-/Sites-master-catalog/default/dw1a708a73/tillys/images/catalog/1000x1000/282135957.jpg?sw=539&sh=693&sm=fit'
+
+donkey kong 'https://images-na.ssl-images-amazon.com/images/I/61r7D94j4EL._UX385_.jpg'
+
+zelda 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTkIKxHNuQIhi_Kgn9KZLsOGMEFao8PDRYU1XGvUiUGcGE_1Y8Wyg'
+
+duck hunt 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQx2PjVr7w2S3l3waMeoJNV6uIgmjC1570zyx71w1XTinVT70um'
+
+poke ball sock 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRxEfPgBmV0E_2jZt1MJM3IxpNkDZaqs9mrmxjf7GPNs6GN-JOc'
+
+charizard 'https://www.pokemoncenter.com/wcsstore/PokemonCatalogAssetStore/images/catalog/products/P3637/741-03173/P3637_741-03173_01.jpg'
+
+3 pack pikachu 'http://eurekashop.se/16105-large_default/3-pack-pokemon-pikachu-socks-pokemon-socks-3-pair-material-70-cotton-27-polyamide-3-elasthan-choose-size-23-26-27-30-31-34-35-37.jpg'
+
+dragonball z kame 'https://dtpmhvbsmffsz.cloudfront.net/posts/2017/10/16/59e4b67e2ba50a2efc0ba5cc/m_59e4b69213302a89e40bb5b6.jpg'
+
+wu tang clan 'https://images-na.ssl-images-amazon.com/images/I/51KOwILMDXL._UX679_.jpg'
+
+rhcp 'https://i.kym-cdn.com/entries/icons/facebook/000/015/206/205797150.jpg'
+
+rhcp 2 'https://78.media.tumblr.com/tumblr_mcip40VMyC1roaxc3o1_250.jpg'
+
+ren and stimpy five pk 'https://cdn2.bigcommerce.com/n-nr1m3w/b72t4x/products/100723/images/113640/Ren_and_Stimpy_Characters_5_Pack_Low_Cut_Socks__22570.1524199228.380.500.jpg?c=2'
+
+rockos modern life no sho 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQa6SQr2gR3zF8j_qTRs7q1PNHWrrbanZOnpMG4Lcs73G-jBMrDhA'
+
+catdog 'https://cdn.shopify.com/s/files/1/0317/1509/products/Catch_Dog_FOOT_1.jpg'
+
+looney tunes 'https://cdn.shopify.com/s/files/1/1390/4303/products/socks-looney-tunes-printed-socks-3_2048x@2x.jpg?v=1520094839'
+
+looney tunes martian 'https://s7d9.scene7.com/is/image/JCPenney/DP0111201815162652M?resmode=sharp2&op_sharpen=1&wid=550&hei=550'
+
+tetris 'https://www.geekalerts.com/u/Mens-Tetris-Sock.jpg'
+
+pacman 'https://www.pussyfootsocks.com.au/pub/media/catalog/product/cache/2a8d341df1aabef95fa418beb77089e8/s/y/syj_5779_masked.jpg'
+
+space invaders 'https://cdn.shopify.com/s/files/1/1015/9053/products/space-invaders-socks.png?v=1520332166'
+
+spongebob 'https://images-na.ssl-images-amazon.com/images/I/81f5TozfheL._UX385_.jpg'
+
+superman 'https://images-na.ssl-images-amazon.com/images/I/514NkHIUtBL.jpg'
+
+patrick starfish 3 pack 'https://i5.walmartimages.com/asr/10a971b5-cf33-4b48-9050-db6ceab15ed1_1.530a6e3cd8ca531396393515d358b309.jpeg?odnWidth=282&odnHeight=376&odnBg=ffffff'
+
+trump hair 'https://i.pinimg.com/originals/76/f4/1c/76f41ca5d1b1cb1758ff2327114c0c66.jpg'
+
+beer 'https://cdn.shopify.com/s/files/1/0072/1432/products/beersock_700x.jpg?v=1536232527'
+
+worst gift ever 'https://i.ebayimg.com/images/g/S1MAAOSwuMZZJaMZ/s-l300.jpg'
+
+5 pk cartoon dogs 'https://ae01.alicdn.com/kf/HTB109TLklDH8KJjy1zeq6xjepXal/Casual-Cute-Women-Socks-Cartoon-Dogs-Whale-Bear-Duck-Lovely-Crew-Socks-Harajuku-Female-Creative-Funny.jpg_640x640.jpg'
+
+monkey biz 'https://cdn1.bigcommerce.com/server2500/0iaufi/products/4215/images/41767/SOC19__02196.1431537423.1280.1280.jpg?c=2'
+
+cool cat 'https://cdn.shopify.com/s/files/1/1631/8771/products/HM100587-BLUE_png_2000x.jpg?v=1494449011'
+
+van gogh self portrait 'https://store.philamuseum.org/mas_assets/cache/image/1/3/b/6/5046.Jpg'
+
+dali melting clocks 'https://images-na.ssl-images-amazon.com/images/I/61mpXR6ZQEL._UX385_.jpg'
+
+dali assorted 3 pak 'https://cdn.shopify.com/s/files/1/2004/9937/products/surrealpack_900x.jpg?v=1520409783'
+
+dali persistence of memory 'https://cdn.shopify.com/s/files/1/1329/9859/products/XMDM542_FLATLAY_1024x1024.jpg?v=1522359358'
+
+white walker GOT 'https://i.pinimg.com/originals/e5/3a/4a/e53a4a35295f5a9a021e9d55e2665af0.jpg'
+
+super smash bros 'https://www.artistshot.com/assets/images/admin/product_design/2058637/super-smash-bros-2-socks-420x420.jpg'
+
+chocobo final fantasy 'https://images-na.ssl-images-amazon.com/images/I/51%2BFfPGFqlL._UX679_.jpg'
+
+futurama bender jordan 'https://images-na.ssl-images-amazon.com/images/I/51qpwYI89eL._UX385_.jpg'
+
+adidas soccer 'http://i.ebayimg.com/00/s/NTAwWDUwMA==/z/hwsAAMXQrhdTVhqt/$_3.JPG?set_id=2'
+
+american football 'http://sc02.alicdn.com/kf/HTB12jGiJFXXXXcIaXXXq6xXFXXXr/Mens-Sports-Apparel-White-and-Blue-Stripes.jpg'
+
+hockey skate sock 'http://www.thehockeyshop.com/media/catalog/product/cache/1/image/1920x1920/9df78eab33525d08d6e5fb8d27136e95/c/c/ccmprolinecutresistanceskatesocks.jpg'
+
+

--- a/client/store/orders.js
+++ b/client/store/orders.js
@@ -20,9 +20,9 @@ export const gotOrderHistory = orders => ({type: GET_ORDER_HISTORY, orders})
 
 // THUNK CREATORS
 
-export const postOrder = userId => async dispatch => {
+export const postOrder = (userId, sockId) => async dispatch => {
   try { 
-    const {data: order} = await axios.post(`/api/orders/${userId}`);
+    const {data: order} = await axios.post(`/api/orders/${userId}/${sockId}`);
     dispatch(receiveOrder(order))
   } catch (err) {
     console.error(err);
@@ -31,7 +31,6 @@ export const postOrder = userId => async dispatch => {
 
 export const fetchOrdersForCart = userId => async dispatch => {
   try {
-    console.log('USER ID:   ',userId)
     const {data: orders} = await axios.get(`/api/orders/${userId}`);
     dispatch(gotOrdersForCart(orders))
   } catch (err) {

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -17,7 +17,13 @@ router.get('/:userId', async (req, res, next) => {
 // ==> create new users cart <== //
 router.post('/:userId', async (req, res, next) => {
   try {
-    const order = await Order.create({ userId : req.params.userId});
+    const order = await Order.findOrCreate({where: {
+        userId: req.params.userId  
+      }
+    });
+
+    //associate order and sock in our join table
+
     res.json(order);
   } catch (err) {
       next(err);

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -15,14 +15,15 @@ router.get('/:userId', async (req, res, next) => {
 });
 
 // ==> create new users cart <== //
-router.post('/:userId', async (req, res, next) => {
+router.post('/:userId/:sockId', async (req, res, next) => {
   try {
-    const order = await Order.findOrCreate({where: {
-        userId: req.params.userId  
+    const sock = await Sock.findById(req.params.sockId)
+    const [order] = await Order.findOrCreate({where: {
+        userId: req.params.userId,
+        sold: false
       }
     });
-
-    //associate order and sock in our join table
+    order.addSock(sock)
 
     res.json(order);
   } catch (err) {

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -1,12 +1,13 @@
 const {User} = require('./user')
 const {Sock} = require('./sock')
 const {Order} = require('./order')
+const {itemInCart} = require('./item-in-cart')
 
 User.hasMany(Order);
 Order.belongsTo(User);
 
-Sock.belongsToMany(Order, {through: 'itemsInCart'});
-Order.belongsToMany(Sock, {through: 'itemsInCart'});
+Sock.belongsToMany(Order, {through: itemInCart});
+Order.belongsToMany(Sock, {through: itemInCart});
 
 module.exports = {
   User,

--- a/server/db/models/item-in-cart.js
+++ b/server/db/models/item-in-cart.js
@@ -1,0 +1,12 @@
+const Sequelize = require('sequelize');
+const db = require('../db');
+
+const itemInCart = db.define('cart-item', {
+  quantity: {
+    type: Sequelize.INTEGER
+  }
+})
+
+module.exports = {
+  itemInCart
+}


### PR DESCRIPTION
## What did you change?
Changed postOrder thunk and post route to expect /:sockId

## What did it fix or what is now possible because of your change?
'cart-item' join table now receives 'sockId' and 'orderId' when addToCart button fires

## Is there anything that needs to happen as a result of this change?
implement remaining cart functionality

## Are there any questions you had about the implementation or other possibilities you'd like the reviewers to consider?
nopey dope

=(^.^)=


